### PR TITLE
refactored sidebar

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -3,50 +3,42 @@
 <ul id="mysidebar" class="nav">
   <li class="sidebarTitle">{{sidebar[0].product}} {{sidebar[0].version}}</li>
   {% for entry in sidebar %}
-  {% for folder in entry.folders %}
-  {% if folder.output contains "web" %}
-  <li>
-      <a title="{{folder.title}}" href="#">{{folder.title}}</a>
-      <ul>
-          {% for folderitem in folder.folderitems %}
-          {% if folderitem.output contains "web" %}
-          {% if folderitem.external_url %}
-          <li><a title="{{folderitem.title}}" href="{{folderitem.external_url}}" target="_blank" rel="noopener">{{folderitem.title}}</a></li>
-          {% elsif page.url == folderitem.url %}
-          <li class="active"><a title="{{folderitem.title}}" href="{{folderitem.url | remove: "/"}}">{{folderitem.title}}</a></li>
-          {% elsif folderitem.type == "empty" %}
-          <li><a title="{{folderitem.title}}" href="{{folderitem.url | remove: "/"}}">{{folderitem.title}}</a></li>
+    {% for folder in entry.folders %}
+      <li>
+          <a title="{{folder.title}}" href="#">{{folder.title}}</a>
+          <ul>
+              {% for folderitem in folder.folderitems %}
+                {% if folderitem.external_url %}
+                  <li><a title="{{folderitem.title}}" href="{{folderitem.external_url}}" target="_blank" rel="noopener">{{folderitem.title}}</a></li>
+                {% elsif page.url == folderitem.url %}
+                  <li class="active"><a title="{{folderitem.title}}" href="{{folderitem.url | remove: "/"}}">{{folderitem.title}}</a></li>
+                {% elsif folderitem.type == "empty" %}
+                  <li><a title="{{folderitem.title}}" href="{{folderitem.url | remove: "/"}}">{{folderitem.title}}</a></li>
 
-          {% else %}
-          <li><a title="{{folderitem.title}}" href="{{folderitem.url | remove: "/"}}">{{folderitem.title}}</a></li>
-          {% endif %}
-          {% for subfolders in folderitem.subfolders %}
-          {% if subfolders.output contains "web" %}
-          <li class="subfolders">
-              <a title="{{subfolders.title}}" href="#">{{ subfolders.title }}</a>
-              <ul>
-                  {% for subfolderitem in subfolders.subfolderitems %}
-                  {% if subfolderitem.output contains "web" %}
-                  {% if subfolderitem.external_url %}
-                  <li><a title="{{subfolderitem.title}}" href="{{subfolderitem.external_url}}" target="_blank" rel="noopener">{{subfolderitem.title}}</a></li>
-                  {% elsif page.url == subfolderitem.url %}
-                  <li class="active"><a title="{{subfolderitem.title}}" href="{{subfolderitem.url | remove: "/"}}">{{subfolderitem.title}}</a></li>
-                  {% else %}
-                  <li><a title="{{subfolderitem.title}}" href="{{subfolderitem.url | remove: "/"}}">{{subfolderitem.title}}</a></li>
-                  {% endif %}
-                  {% endif %}
-                  {% endfor %}
-              </ul>
-          </li>
-          {% endif %}
-          {% endfor %}
-          {% endif %}
-          {% endfor %}
-      </ul>
-   </li>
-     {% endif %}
-      {% endfor %}
-      {% endfor %}
+                {% else %}
+                  <li><a title="{{folderitem.title}}" href="{{folderitem.url | remove: "/"}}">{{folderitem.title}}</a></li>
+                {% endif %}
+                {% for subfolders in folderitem.subfolders %}
+                  <li class="subfolders">
+                      <a title="{{subfolders.title}}" href="#">{{ subfolders.title }}</a>
+                      <ul>
+                          {% for subfolderitem in subfolders.subfolderitems %}
+                            {% if subfolderitem.external_url %}
+                              <li><a title="{{subfolderitem.title}}" href="{{subfolderitem.external_url}}" target="_blank" rel="noopener">{{subfolderitem.title}}</a></li>
+                              {% elsif page.url == subfolderitem.url %}
+                              <li class="active"><a title="{{subfolderitem.title}}" href="{{subfolderitem.url | remove: "/"}}">{{subfolderitem.title}}</a></li>
+                              {% else %}
+                              <li><a title="{{subfolderitem.title}}" href="{{subfolderitem.url | remove: "/"}}">{{subfolderitem.title}}</a></li>
+                            {% endif %}
+                          {% endfor %}
+                      </ul>
+                  </li>
+                {% endfor %}
+              {% endfor %}
+          </ul>
+      </li>
+    {% endfor %}
+  {% endfor %}
       <!-- if you aren't using the accordion, uncomment this block:
          <p class="external">
              <a href="#" id="collapseAll">Collapse All</a> | <a href="#" id="expandAll">Expand All</a>


### PR DESCRIPTION
* made subfolder its own type, rather than the weird attachment to a folderitem that was previously implemented

* removed pluralization of `subfolders`, now it's just `subfolder`

* removed required `output: web` line for each entry

new sidebar with all levels looks like
```yaml
entries:
  - product: Vehicles
    folders:
      - title: Cars
        folderitems:
          - title: Car Overview
            url: car_overview.html
          - subfolder:
              - title: Luxury
                subfolderitems:
                  - title: Lexus
                    url: /lexus.html
                  - title: Tesla
                    url: /tesla.html
          - subfolder:
              - title: Sports
                subfolderitems:
                  - title: Ferarri
                    url: /ferarri.html
      - title: Trucks
        folderitems:
          - title: Utility
            url: /utility_trucks.html
          - title: Semi
            url: /semitrucks.html
```
